### PR TITLE
ci: remove nodejs runtime configuration from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -14,10 +14,5 @@
       "src": "/(.*)",
       "dest": "/index.html"
     }
-  ],
-  "functions": {
-    "app/api/**/*.js": {
-      "runtime": "nodejs18.x"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
The runtime configuration is no longer needed as we're moving to a different deployment approach