### PR TITLE
fix: correct path to main.scss import

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,1 +1,1 @@
-@import '/assets/sass/main.scss';
+@import '../public/assets/sass/main.scss';


### PR DESCRIPTION
The previous path was incorrect and caused compilation errors. Updated to use the correct relative path from the src directory.