### PR TITLE
fix(routing): add assets route to prevent 404 errors

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/assets/* /assets/:splat 200
 /* /index.html 200

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
   ],
   "routes": [
     {
+      "src": "/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
     }


### PR DESCRIPTION
The previous configuration didn't properly handle asset requests, causing 404 errors. Added explicit routing for assets in both _redirects and vercel.json to ensure proper asset delivery.